### PR TITLE
Fix missing backticks and longer messages

### DIFF
--- a/src/methods/constructEmbed.ts
+++ b/src/methods/constructEmbed.ts
@@ -5,8 +5,8 @@ export default function constructEmbed(commit: Commit): MessageEmbed {
   return new MessageEmbed({
     title: commit.title,
     description:
-      commit.description.length > 2000
-        ? `${commit.description.substr(0, 2000)}...`
+      commit.description.length > 4091
+        ? `${commit.description.substr(0, 4091)}…\n\`\`\``
         : commit.description,
     url: commit.url,
     author: {


### PR DESCRIPTION
This PR fixes a bug which would break the displaying of codeblocks when commit descriptions are too long (the last three backticks would be cut off and thus the codeblock wouldn't display correctly) as well as extending the character limit check to 4091 (4096 minus 1 for the three dots special character, 1 for the new line and 3 for the extra backticks)

### What this pull request aims at fixing
![What this pull requests aims at fixing](https://media.discordapp.net/attachments/802590021575639111/934173598669742140/context.jpg)